### PR TITLE
Fix required csp tweaks for asset loading

### DIFF
--- a/data/episodes/3-style-your-app-with-bulma.md
+++ b/data/episodes/3-style-your-app-with-bulma.md
@@ -62,25 +62,7 @@ Then run `npm start` to run my assets server and when I check the browser, you c
 ```ruby
 # config/application.rb
 
-config.actions.default_headers = {
-  "X-Frame-Options" => "DENY",
-  "X-Content-Type-Options" => "nosniff",
-  "X-XSS-Protection" => "1; mode=block",
-  "Content-Security-Policy" => \
-    "base-uri 'self'; " \
-    "child-src 'self'; " \
-    "connect-src 'self'; " \
-    "default-src 'none'; " \
-    "font-src 'self'; " \
-    "form-action 'self'; " \
-    "frame-ancestors 'self'; " \
-    "frame-src 'self'; " \
-    "img-src 'self' https: data:; " \
-    "media-src 'self'; " \
-    "object-src 'none'; " \
-    "script-src 'localhost'; " \
-    "style-src * 'unsafe-inline'"
-  }
+config.actions.content_security_policy[:default_src] = "'self' http://localhost:8080"
 ```
 
 ![Article's grid](/images/episodes/3/bulma-installed.png)


### PR DESCRIPTION
The current suggested default headers didn't seem to work for me.

Before:
![before](https://user-images.githubusercontent.com/675705/166583034-a4c42fff-7932-44fd-ab59-eca6d0ddab5d.png)

After:
![after](https://user-images.githubusercontent.com/675705/166583086-b80f0680-4e8a-46a1-9278-7d35abae49bc.png)

