### PR TITLE
9 fix the sharing counter when navigating between pages

### DIFF
--- a/features/share-buttons.jsx
+++ b/features/share-buttons.jsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import { StickyShareButtons } from 'sharethis-reactjs';
 
-export default function ShareButtons() {
+export default function ShareButtons({ data }) {
+  const { url, thumbnail, topic } = data;
   return (
     <StickyShareButtons
       config={{
@@ -30,6 +31,9 @@ export default function ShareButtons() {
         show_toggle: true, // show/hide the toggle buttons (true, false)
         size: 48, // the size of each button (INTEGER)
         top: 160, // offset in pixels from the top of the page
+        url,
+        title: topic,
+        thumbnail: thumbnail.small,
       }}
     />
   );

--- a/features/share-buttons.jsx
+++ b/features/share-buttons.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { StickyShareButtons } from 'sharethis-reactjs';
 
 export default function ShareButtons({ data }) {
-  const { url, thumbnail, topic } = data;
+  const { url, thumbnail, title } = data;
+
   return (
     <StickyShareButtons
       config={{
@@ -32,8 +33,8 @@ export default function ShareButtons({ data }) {
         size: 48, // the size of each button (INTEGER)
         top: 160, // offset in pixels from the top of the page
         url,
-        title: topic,
-        thumbnail: thumbnail.small,
+        title,
+        image: thumbnail.small,
       }}
     />
   );

--- a/layouts/article-layout/article-layout.jsx
+++ b/layouts/article-layout/article-layout.jsx
@@ -60,7 +60,7 @@ const ArticleLayout = ({ article, children }) => {
             <ArticleTabs />
           </Grid>
           <Grid item sm={12} md={8} lg={7} xl={6} component="article">
-            <ShareButtons />
+            <ShareButtons data={article} />
             {displayArticle && children}
             {displayDiscussions && (
               <Discussions

--- a/layouts/episode-layout/episode-layout.jsx
+++ b/layouts/episode-layout/episode-layout.jsx
@@ -90,7 +90,7 @@ const EpisodeLayout = ({ episode, children }) => {
             component="article"
             className={classes.article}
           >
-            <ShareButtons />
+            <ShareButtons data={episode} />
             {displayVideo && <YoutubeEmbed embedId={videoId} />}
             {displayArticle && children}
             {displayDiscussions && (

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
 import { ServerStyleSheets } from '@material-ui/core/styles';
 import theme from '../styles/theme';
 
@@ -21,10 +22,9 @@ export default class MyDocument extends Document {
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
           />
-          <script
-            type="text/javascript"
+          <Script
             src="https://platform-api.sharethis.com/js/sharethis.js#property=60b823ffeed0fd001128d645&product=sticky-share-buttons"
-            async="async"
+            strategy="beforeInteractive"
           />
         </Head>
         <body>


### PR DESCRIPTION
Not only the sharing counter wasn't updating but also url and title metadata. It seems like it is a problem of the package that it always get initial metadata (after refresh) but ignores further changes of the metadata.

- added passing metadata of the article/episode page by props
- changed  sharethis script to beforeInteractive (to make sure component will render only after the script is loaded) 