### PR TITLE
12 add related articles component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,8 @@
     "react/jsx-props-no-spreading": "off",
     "no-underscore-dangle": "off",
     "react/no-unescaped-entities": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "no-param-reassign": "off",
+    "no-plusplus": "off"
   }
 }

--- a/features/content-grid/index.jsx
+++ b/features/content-grid/index.jsx
@@ -21,7 +21,7 @@ const ContentDisplay = (props) => {
           key={item.id}
           item
           xs={12}
-          md={index === 0 && !relatedContent ? 12 : 4}
+          md={index === 0 && !relatedContent ? 12 : 6}
           component="li"
         >
           <ContentTile

--- a/features/content-grid/index.jsx
+++ b/features/content-grid/index.jsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
 
 const ContentDisplay = (props) => {
   const classes = useStyles();
-  const { items } = props;
+  const { items, relatedContent } = props;
   return (
     <Grid container component="ul" className={classes.list} spacing={6}>
       {items.map((item, index) => (
@@ -21,10 +21,13 @@ const ContentDisplay = (props) => {
           key={item.id}
           item
           xs={12}
-          md={index === 0 ? 12 : 6}
+          md={index === 0 && !relatedContent ? 12 : 4}
           component="li"
         >
-          <ContentTile item={item} variant={index === 0 ? 'big' : 'small'} />
+          <ContentTile
+            item={item}
+            variant={index === 0 && !relatedContent ? 'big' : 'small'}
+          />
         </Grid>
       ))}
     </Grid>

--- a/features/content-grid/tile.jsx
+++ b/features/content-grid/tile.jsx
@@ -19,6 +19,9 @@ import TopicList from '../topics/topic-list';
 import ProTag from '../content/pro-tag';
 
 const useStyles = makeStyles((theme) => ({
+  card: {
+    height: '100%',
+  },
   content: {
     display: 'flex',
     flexDirection: 'column',

--- a/features/related-content.jsx
+++ b/features/related-content.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function RelatedContent({ topics }) {
+  return (
+    <>
+      <div>
+        {topics.map((item) => (
+          <div>{item}</div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/features/related-content.jsx
+++ b/features/related-content.jsx
@@ -1,4 +1,4 @@
-import { Box, Typography, makeStyles } from '@material-ui/core';
+import { Container, Typography, makeStyles } from '@material-ui/core';
 import React from 'react';
 import ContentDisplay from './content-grid';
 
@@ -11,6 +11,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     gap: '1rem',
     marginTop: '1rem',
+    padding: theme.spacing(0, 0, 0, 4),
   },
 }));
 
@@ -18,9 +19,9 @@ export default function RelatedContent({ posts }) {
   const classes = useStyles();
 
   return (
-    <Box className={classes.container}>
+    <Container className={classes.container}>
       <Typography variant="h2">Related Content</Typography>
       <ContentDisplay items={posts} relatedContent />
-    </Box>
+    </Container>
   );
 }

--- a/features/related-content.jsx
+++ b/features/related-content.jsx
@@ -9,8 +9,8 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    gap: '1rem',
-    marginTop: '1rem',
+    gap: '20px',
+    marginTop: '20px',
     padding: theme.spacing(0, 0, 0, 4),
   },
 }));
@@ -20,7 +20,7 @@ export default function RelatedContent({ posts }) {
 
   return (
     <Container className={classes.container}>
-      <Typography variant="h2">Related Content</Typography>
+      <Typography variant="h3">Related or recent posts</Typography>
       <ContentDisplay items={posts} relatedContent />
     </Container>
   );

--- a/features/related-content.jsx
+++ b/features/related-content.jsx
@@ -1,13 +1,26 @@
+import { Box, Typography, makeStyles } from '@material-ui/core';
 import React from 'react';
+import ContentDisplay from './content-grid';
 
-export default function RelatedContent({ topics }) {
+const useStyles = makeStyles((theme) => ({
+  container: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: '1rem',
+    marginTop: '1rem',
+  },
+}));
+
+export default function RelatedContent({ posts }) {
+  const classes = useStyles();
+
   return (
-    <>
-      <div>
-        {topics.map((item) => (
-          <div>{item}</div>
-        ))}
-      </div>
-    </>
+    <Box className={classes.container}>
+      <Typography variant="h2">Related Content</Typography>
+      <ContentDisplay items={posts} relatedContent />
+    </Box>
   );
 }

--- a/features/related-content.jsx
+++ b/features/related-content.jsx
@@ -20,7 +20,7 @@ export default function RelatedContent({ posts }) {
 
   return (
     <Container className={classes.container}>
-      <Typography variant="h3">Related or recent posts</Typography>
+      <Typography variant="h3">May also interest you...</Typography>
       <ContentDisplay items={posts} relatedContent />
     </Container>
   );

--- a/pages/articles/[slug].jsx
+++ b/pages/articles/[slug].jsx
@@ -1,14 +1,20 @@
 import { MDXRemote } from 'next-mdx-remote';
 import components from '../../features/mdx-components';
 import ArticleLayout from '../../layouts/article-layout';
-import { getContentBySlug, getContent } from '../../utils/queries';
+import {
+  getContentBySlug,
+  getContent,
+  getRelatedContent,
+} from '../../utils/queries';
 import TopicSuggestion from '../../features/topic-suggestion';
+import RelatedContent from '../../features/related-content';
 
-export default function Article({ mdxSource, frontMatter }) {
+export default function Article({ mdxSource, frontMatter, relatedContent }) {
   return (
     <ArticleLayout article={frontMatter}>
       <MDXRemote {...mdxSource} components={components} />
       <TopicSuggestion />
+      <RelatedContent posts={relatedContent} />
     </ArticleLayout>
   );
 }
@@ -24,5 +30,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const post = await getContentBySlug('articles', params.slug);
-  return { props: { ...post } };
+  const relatedContent = await getRelatedContent(post.frontMatter);
+
+  return { props: { ...post, relatedContent } };
 }

--- a/pages/episodes/[slug].jsx
+++ b/pages/episodes/[slug].jsx
@@ -3,13 +3,19 @@ import { MDXRemote } from 'next-mdx-remote';
 import components from '../../features/mdx-components';
 import TopicSuggestion from '../../features/topic-suggestion';
 import EpisodeLayout from '../../layouts/episode-layout';
-import { getContent, getContentBySlug } from '../../utils/queries';
+import {
+  getContent,
+  getContentBySlug,
+  getRelatedContent,
+} from '../../utils/queries';
+import RelatedArticles from '../../features/related-content';
 
-export default function Episode({ mdxSource, frontMatter }) {
+export default function Episode({ mdxSource, frontMatter, relatedPosts }) {
   return (
     <EpisodeLayout episode={frontMatter}>
       <MDXRemote {...mdxSource} components={components} />
       <TopicSuggestion />
+      {/* <RelatedArticles topics={relatedPosts} /> */}
     </EpisodeLayout>
   );
 }
@@ -25,5 +31,6 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const post = await getContentBySlug('episodes', params.slug);
-  return { props: { ...post } };
+  const relatedPosts = await getRelatedContent(post.frontMatter);
+  return { props: { ...post, relatedPosts } };
 }

--- a/pages/episodes/[slug].jsx
+++ b/pages/episodes/[slug].jsx
@@ -8,14 +8,14 @@ import {
   getContentBySlug,
   getRelatedContent,
 } from '../../utils/queries';
-import RelatedArticles from '../../features/related-content';
+import RelatedContent from '../../features/related-content';
 
 export default function Episode({ mdxSource, frontMatter, relatedContent }) {
   return (
     <EpisodeLayout episode={frontMatter}>
       <MDXRemote {...mdxSource} components={components} />
       <TopicSuggestion />
-      <RelatedArticles posts={relatedContent} />
+      <RelatedContent posts={relatedContent} />
     </EpisodeLayout>
   );
 }

--- a/pages/episodes/[slug].jsx
+++ b/pages/episodes/[slug].jsx
@@ -10,12 +10,12 @@ import {
 } from '../../utils/queries';
 import RelatedArticles from '../../features/related-content';
 
-export default function Episode({ mdxSource, frontMatter, relatedPosts }) {
+export default function Episode({ mdxSource, frontMatter, relatedContent }) {
   return (
     <EpisodeLayout episode={frontMatter}>
       <MDXRemote {...mdxSource} components={components} />
       <TopicSuggestion />
-      {/* <RelatedArticles topics={relatedPosts} /> */}
+      <RelatedArticles posts={relatedContent} />
     </EpisodeLayout>
   );
 }
@@ -31,6 +31,6 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const post = await getContentBySlug('episodes', params.slug);
-  const relatedPosts = await getRelatedContent(post.frontMatter);
-  return { props: { ...post, relatedPosts } };
+  const relatedContent = await getRelatedContent(post.frontMatter);
+  return { props: { ...post, relatedContent } };
 }

--- a/utils/queries.js
+++ b/utils/queries.js
@@ -100,6 +100,8 @@ async function getContentByTopic(topic) {
 async function getRelatedContent(post) {
   const { topics: relatedTopics, id } = post;
 
+  const relatedPostsReturned = 4;
+
   const posts = await getContent();
   const postsWithTopic = posts.filter((item) =>
     item.topics.some((topic) => relatedTopics.includes(topic))
@@ -125,11 +127,23 @@ async function getRelatedContent(post) {
     (a, b) => b.topicCount - a.topicCount
   );
 
-  const relatedPostsReturned = 3;
+  if (sortedRelatedPosts.length < relatedPostsReturned) {
+    const amountOfRelatedPosts =
+      relatedPostsReturned - sortedRelatedPosts.length;
+    const filterRelatedPosts = posts.filter(
+      (item) =>
+        item.id !== id && sortedRelatedPosts.some((i) => i.id !== item.id)
+    );
 
-  const slicedRelatedPosts = sortedRelatedPosts.slice(0, relatedPostsReturned);
+    return [
+      ...sortedRelatedPosts,
+      ...filterRelatedPosts.slice(0, amountOfRelatedPosts),
+    ];
+  }
 
-  return slicedRelatedPosts;
+  const sliceRelatedPosts = sortedRelatedPosts.slice(0, relatedPostsReturned);
+
+  return sliceRelatedPosts;
 }
 
 exports.getContentBySlug = getContentBySlug;

--- a/utils/queries.js
+++ b/utils/queries.js
@@ -123,25 +123,20 @@ async function getRelatedContent(post) {
     []
   );
 
-  const sortedRelatedPosts = countRelatedTopics.sort(
+  const sortRelatedPosts = countRelatedTopics.sort(
     (a, b) => b.topicCount - a.topicCount
   );
 
-  if (sortedRelatedPosts.length < relatedPostsReturned) {
-    const amountOfRelatedPosts =
-      relatedPostsReturned - sortedRelatedPosts.length;
-    const filterRelatedPosts = posts.filter(
-      (item) =>
-        item.id !== id && sortedRelatedPosts.some((i) => i.id !== item.id)
+  if (sortRelatedPosts.length < relatedPostsReturned) {
+    const amountOfRecentPosts = relatedPostsReturned - sortRelatedPosts.length;
+    const filterPosts = posts.filter(
+      (item) => item.id !== id && sortRelatedPosts.some((i) => i.id !== item.id)
     );
 
-    return [
-      ...sortedRelatedPosts,
-      ...filterRelatedPosts.slice(0, amountOfRelatedPosts),
-    ];
+    return [...sortRelatedPosts, ...filterPosts.slice(0, amountOfRecentPosts)];
   }
 
-  const sliceRelatedPosts = sortedRelatedPosts.slice(0, relatedPostsReturned);
+  const sliceRelatedPosts = sortRelatedPosts.slice(0, relatedPostsReturned);
 
   return sliceRelatedPosts;
 }

--- a/utils/queries.js
+++ b/utils/queries.js
@@ -94,6 +94,7 @@ async function getContent(type) {
 */
 async function getContentByTopic(topic) {
   const posts = await getContent();
+
   return posts.filter((item) => item.topics.includes(topic));
 }
 
@@ -102,7 +103,10 @@ async function getRelatedContent(post) {
 
   const relatedPostsReturned = 4;
 
-  const posts = await getContent();
+  const content = await getContent();
+
+  const posts = content.sort((a, b) => b.publishedAt - a.publishedAt);
+
   const postsWithTopic = posts.filter((item) =>
     item.topics.some((topic) => relatedTopics.includes(topic))
   );
@@ -136,9 +140,7 @@ async function getRelatedContent(post) {
     return [...sortRelatedPosts, ...filterPosts.slice(0, amountOfRecentPosts)];
   }
 
-  const sliceRelatedPosts = sortRelatedPosts.slice(0, relatedPostsReturned);
-
-  return sliceRelatedPosts;
+  return sortRelatedPosts.slice(0, relatedPostsReturned);
 }
 
 exports.getContentBySlug = getContentBySlug;

--- a/utils/queries.js
+++ b/utils/queries.js
@@ -97,6 +97,42 @@ async function getContentByTopic(topic) {
   return posts.filter((item) => item.topics.includes(topic));
 }
 
+async function getRelatedContent(post) {
+  const { topics: relatedTopics, id } = post;
+
+  const posts = await getContent();
+  const postsWithTopic = posts.filter((item) =>
+    item.topics.some((topic) => relatedTopics.includes(topic))
+  );
+
+  const countRelatedTopics = postsWithTopic.reduce(
+    (postsWithTopicAcc, postWithTopic) => {
+      if (postWithTopic.id === id) return postsWithTopicAcc;
+      const topicCount = postWithTopic.topics.reduce((topicsAcc, topic) => {
+        relatedTopics.forEach((item) => {
+          if (topic === item) topicsAcc++;
+        });
+        return topicsAcc;
+      }, 0);
+
+      postsWithTopicAcc.push({ topicCount, ...postWithTopic });
+      return postsWithTopicAcc;
+    },
+    []
+  );
+
+  const sortedRelatedPosts = countRelatedTopics.sort(
+    (a, b) => b.topicCount - a.topicCount
+  );
+
+  const relatedPostsReturned = 3;
+
+  const slicedRelatedPosts = sortedRelatedPosts.slice(0, relatedPostsReturned);
+
+  return slicedRelatedPosts;
+}
+
 exports.getContentBySlug = getContentBySlug;
 exports.getContent = getContent;
 exports.getContentByTopic = getContentByTopic;
+exports.getRelatedContent = getRelatedContent;


### PR DESCRIPTION
- added `getRelatedContent`  function that accept article/episode as an argument. It returns related articles/episodes in the following priority:

1. Amount of shared topics
2. Date of publication

If the amount of related content is too small (for example only 2 episodes with the same topic), most recent articles/episodes will be added as related( to match by default 4 articles/episodes),

- added `RelatedContent` component that renders related article/episodes,

- fixed height difference in content-grid tiles.





